### PR TITLE
Adjust to SDK changes in 9.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For these cases, you can use this repo as a starting point and adapt it as requi
 
 ## Prerequisites
 
-Before using this plugin you must be running version 9.0 or later of the Curity Identity Server.\
+Before using this plugin you must be running version 9.2 or later of the Curity Identity Server.\
 Also ensure that you are using [credential_mode=standard](https://curity.io/docs/idsvr/latest/system-admin-guide/data-sources/jdbc.html#credential-modes) for your credential manager.\
 If you are using older credential storage, use v3.0 of this repo instead.
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.curity.identityserver.plugin</groupId>
     <artifactId>identityserver.plugins.authenticators.usernamepassword</artifactId>
-    <version>4.0.0</version>
+    <version>4.1.0</version>
     <packaging>jar</packaging>
     <name>Username Password Authenticator</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.curityVersion>9.0.0</project.curityVersion>
+        <project.curityVersion>9.2.0</project.curityVersion>
         <project.slf4jVersion>2.0.3</project.slf4jVersion>
         <project.hibernateValidatorVersion>7.0.3.Final</project.hibernateValidatorVersion>
         <project.guavaVersion>33.0.0-jre</project.guavaVersion>


### PR DESCRIPTION
Replace usages of `AccountManager#create` with `AccountManager#createAccount`. The former method was experimental and has been removed in 9.2.