### PR TITLE
fix: missing attribute id when activating the account

### DIFF
--- a/src/main/java/io/curity/identityserver/plugin/usernamepassword/registration/UsernamePasswordRegistrationRequestHandler.java
+++ b/src/main/java/io/curity/identityserver/plugin/usernamepassword/registration/UsernamePasswordRegistrationRequestHandler.java
@@ -151,7 +151,7 @@ public final class UsernamePasswordRegistrationRequestHandler implements Registr
 
         try
         {
-         account =  _accountManager.withCredentialManager(_userCredentialManager).createAccount(account);
+         account = _accountManager.withCredentialManager(_userCredentialManager).createAccount(account);
         }
         catch (CredentialUpdateException e)
         {

--- a/src/main/java/io/curity/identityserver/plugin/usernamepassword/registration/UsernamePasswordRegistrationRequestHandler.java
+++ b/src/main/java/io/curity/identityserver/plugin/usernamepassword/registration/UsernamePasswordRegistrationRequestHandler.java
@@ -151,7 +151,7 @@ public final class UsernamePasswordRegistrationRequestHandler implements Registr
 
         try
         {
-            _accountManager.withCredentialManager(_userCredentialManager).createAccount(account);
+         account =  _accountManager.withCredentialManager(_userCredentialManager).createAccount(account);
         }
         catch (CredentialUpdateException e)
         {


### PR DESCRIPTION
Fixes the error : 


```
2025-09-24T15:32:53:242+0000 DEBUG UDfw2QDI 14428a4a {req-519} se.curity.identityserver.data.access.DefaultUserAccountRepository - Data-source has thrown an unexpected error: Missing attribute: id
2025-09-24T15:32:53:242+0000 WARN  UDfw2QDI 14428a4a {req-519} se.curity.identityserver.data.access.DefaultUserAccountRepository - Failed to activate account
se.curity.identityserver.sdk.errors.ExternalServiceException: Unable to activate account
	at se.curity.identityserver.data.access.DefaultUserAccountRepository.withErrorHandling(DefaultUserAccountRepository.java:658) ~[identityserver.core-10.4.1-c79b467a16.jar:10.4.1-c79b467a16]
	at se.curity.identityserver.data.access.DefaultUserAccountRepository.activate(DefaultUserAccountRepository.java:330) ~[identityserver.core-10.4.1-c79b467a16.jar:10.4.1-c79b467a16]
	at se.curity.identityserver.account.NoVerificationAccountActivator.initializeActivation(NoVerificationAccountActivator.java:34) ~[identityserver.core-10.4.1-c79b467a16.jar:10.4.1-c79b467a16]
	at se.curity.identityserver.account.StandardAccountManager.initializeActivation(StandardAccountManager.java:481) ~[identityserver.core-10.4.1-c79b467a16.jar:10.4.1-c79b467a16]
	at se.curity.identityserver.sdk.service.AccountManager.initializeActivation(AccountManager.java:122) ~[identityserver.sdk-10.4.1-c79b467a16.jar:10.4.1-c79b467a16]
	at io.curity.identityserver.plugin.usernamepassword.registration.UsernamePasswordRegistrationRequestHandler.createAccount(UsernamePasswordRegistrationRequestHandler.java:184) ~[?:?]
	at io.curity.identityserver.plugin.usernamepassword.registration.UsernamePasswordRegistrationRequestHandler.post(UsernamePasswordRegistrationRequestHandler.java:126) ~[?:?]
	at io.curity.identityserver.plugin.usernamepassword.registration.UsernamePasswordRegistrationRequestHandler.post(UsernamePasswordRegistrationRequestHandler.java:54) ~[?:?]
	at se.curity.identityserver.web.RequestHandlerSubroute$AdaptedHttpRequestHandler.post(RequestHandlerSubroute.java:532) ~[identityserver.core-10.4.1-c79b467a16.jar:10.4.1-c79b467a16]
	at se.curity.identityserver.web.RequestHandlerSubroute$RequestHandlerControllable.post(RequestHandlerSubroute.java:377) ~[identityserver.core-10.4.1-c79b467a16.jar:10.4.1-c79b467a16]
```

